### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check this [project on Behance] (https://www.behance.net/gallery/20411445/Mobile
 
 1. Include the library as local library project.
 
-    ``` compile 'com.yalantis:phoenix:1.2.3' ```
+    ``` implementation 'com.yalantis:phoenix:1.2.3' ```
 
 2. Include the PullToRefreshView widget in your layout.
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.